### PR TITLE
Add export_data method for raw data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 MixpanelAPI
 ===========
 
-Queries the [Mixpanel Data API](http://mixpanel.com/api/docs/guides/api/v2). Requires node 0.4.0 or higher.
+Queries the [Mixpanel Data API](http://mixpanel.com/api/docs/guides/api/v2).
+Requires node 0.8.0 or higher.
 
 Installation
 ============
-clone this repo, it's not on npm yet.
+Clone this repo; it is not on npm yet. Then, run `npm install` from the top
+directory to install the module dependencies.
 
 Show me the code
 ================
@@ -34,3 +36,33 @@ Note: this was forked from the CoffeScript implementation done by Campfire Labs.
         }
             
     )
+
+Exporting raw data from Mixpanel
+--------------------------------
+
+Mixpanel provides a [raw data export API](https://mixpanel.com/docs/api-documentation/exporting-raw-data-you-inserted-into-mixpanel)
+to dump raw events.
+
+This can be called through the `export_data` method. This takes a callback that
+receives a Node.js Readable Stream. By listening to the `data` event on this
+stream, you receive individual event objects, one at a time.
+
+    mixpanel = require('mixpanel');
+
+    var api_key = 'YOUR API KEY',
+        api_secret = 'YOUR API SECRET';
+
+    var mx = new mixpanel({
+        api_key: api_key,
+        api_secret: api_secret
+    });
+
+    mx.export_data(function(res) {
+        res.on('data', function(event_object) {
+            console.dir(event_object);
+        });
+        res.on('end', function() {
+            console.log('All events have been retrieved');
+        });
+    });
+

--- a/lib/mixpanel.js
+++ b/lib/mixpanel.js
@@ -6,6 +6,7 @@ http = require('http');
 querystring = require('querystring');
 crypto = require('crypto');
 util = require('util');
+es = require('event-stream');
 
 MixpanelAPI = (function() {
     
@@ -24,6 +25,42 @@ MixpanelAPI = (function() {
         if (!this.options.api_key && this.options.api_secret) {
             throw new Error('MixpanelAPI needs token and secret parameters');
         }
+    }
+
+    MixpanelAPI.prototype.export_data = function(params, valid_for, cb) {
+        var params_qs, req, req_opts;
+        if (typeof params !== 'object') {
+            throw new Error('export_data(params, [valid_for], cb) expects an object params');
+        }
+        if (arguments.length === 2 && typeof arguments[1] === 'function') {
+            cb = valid_for;
+            valid_for = null;
+        }
+        valid_for || (valid_for = this.options.default_valid_for);
+        if (typeof cb !== 'function') {
+            throw new Error('export_data(params, [valid_for], cb) expects a function cb');
+        }
+
+        params.api_key = this.options.api_key;
+        params.expire = Math.floor(this._get_utc() / 1000) + valid_for;
+
+        params = this._prep_params(params);
+        params_qs = querystring.stringify(this._sign_params(params));
+
+        req_opts = {
+            host: 'data.mixpanel.com',
+            port: 80,
+            path: '/api/2.0/export/?' + params_qs
+        };
+
+        http.get(req_opts, function(res) {
+          res.setEncoding('utf8');
+          cb(es.pipeline(
+            res,
+            es.split(),
+            es.parse()
+          ));
+        });
     }
     
     MixpanelAPI.prototype.request = function(endpoint, params, valid_for, cb) {

--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
 			"url": "http://thezukunft.com"
 		}
 	],
-    "repositories": [
-        {
-            "type": "git",
-            "url": "http://github.com/mixpanel/mixpanel-node.git"
-        }
-    ],
+    "repository": {
+        "type": "git",
+        "url": "http://github.com/mixpanel/mixpanel-node.git"
+    },
+    "dependencies": {
+        "event-stream": "3.0.x"
+    },
     "engines": {
-        "node": ">= 0.4.0"
+        "node": ">= 0.8.0"
     },
     "main": "./index.js"
 }


### PR DESCRIPTION
Here is an approach to the raw data API that uses a Node.js Readable Stream to return the events. I've added some usage details to the README.md.

Adds dependency event-stream, and bumps Node dependency to 0.8.0 or higher (for streams)
