### PR TITLE
Fix expire calculations

### DIFF
--- a/lib/mixpanel.js
+++ b/lib/mixpanel.js
@@ -42,7 +42,7 @@ MixpanelAPI = (function() {
         }
 
         params.api_key = this.options.api_key;
-        params.expire = Math.floor(this._get_utc() / 1000) + valid_for;
+        params.expire = Math.floor(new Date().getTime() / 1000) + valid_for;
 
         params = this._prep_params(params);
         params_qs = querystring.stringify(this._sign_params(params));
@@ -117,14 +117,6 @@ MixpanelAPI = (function() {
         } catch (e) {
             return cb(e);
         }
-    };
-    
-    MixpanelAPI.prototype._get_utc = function() {
-        var d = new Date(),
-            local_time = d.getTime(),
-			// getTimezoneOffset returns diff in minutes (??? why?)
-            local_offset = d.getTimezoneOffset() * 60 * 1000; 
-        return local_time + local_offset;
     };
     
     MixpanelAPI.prototype._prep_params = function(params) {


### PR DESCRIPTION
Previous way of calculating the expire parameter was incorrect. No need for the MixpanelAPI.prototype._get_utc() method, we can get a UTC timestamp natively via Date.prototype.getTime(). Additionally the _get_utc() was incorrectly implemented in that it was assuming getTime() returns local time and adding the getTimezoneOffset() value instead of subtracting. getTime() returns UTC and getTimezoneOffset() returns the difference in minutes, so positive timezone offsets return negative values and vice versa.
